### PR TITLE
Call coregrind's allocator from krabcake

### DIFF
--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -14,10 +14,10 @@ RSHELLO_TARGET = $(RSHELLO_DIR)/target/release
 #	cd $(srcdir)/$(RSHELLO_DIR) && $(CARGO) build --release
 
 $(RSHELLO_TARGET)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
-	rustc --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
+	rustc --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
 $(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
-	rustc --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
+	rustc --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
 clean-local:
 	cd $(srcdir)/$(RSHELLO_DIR); cargo clean

--- a/krabcake/rs_hello/src/lib.rs
+++ b/krabcake/rs_hello/src/lib.rs
@@ -38,7 +38,7 @@ unsafe impl Sync for ValgrindAllocator {}
 
 unsafe impl GlobalAlloc for ValgrindAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let cc: &[u8] = b"cc"; // TODO: Set a unique identifier here?
+        let cc: &[u8] = b"cc\0"; // TODO: Set a unique identifier here?
         vgPlain_malloc(cc.as_ptr() as *const c_char, layout.size()) as *mut u8
     }
 

--- a/krabcake/rs_hello/src/lib.rs
+++ b/krabcake/rs_hello/src/lib.rs
@@ -1,9 +1,51 @@
 #![feature(core_intrinsics, lang_items, c_size_t)]
+#![feature(c_unwind)]
 #![no_std]
 #![allow(unused_imports)]
 
-use core::ffi::{c_char,c_int,CStr,c_size_t,c_void};
+use core::ffi::{c_char, c_int, c_size_t, c_void, CStr};
 use core::panic::PanicInfo;
+use core::ptr;
+
+extern crate alloc;
+use core::alloc::{GlobalAlloc, Layout};
+
+// Can now import and use anything in alloc
+// use alloc::vec::Vec;
+
+extern "C" {
+    // From krabcake-vg/include/pub_tool_mallocfree.h
+    // Nb: the allocators *always succeed* -- they never return NULL (Valgrind
+    // will abort if they can't allocate the memory).
+    // The 'cc' is a string that identifies the allocation point.  It's used when
+    // --profile-heap=yes is specified.
+    // extern void* VG_(malloc)         ( const HChar* cc, SizeT nbytes );
+    // extern void  VG_(free)           ( void* p );
+    //
+    // Basic types are in krabcake-vg/VEX/pub/libvex_basictypes.h
+    // HChar = C char type
+    // Implementation lives in krabcake-vg/coregrind/m_mallocfree.c
+    fn vgPlain_malloc(cc: *const c_char, nbytes: c_size_t) -> *mut c_void;
+    fn vgPlain_free(p: *mut c_void);
+}
+
+struct ValgrindAllocator;
+
+#[global_allocator]
+static ALLOCATOR: ValgrindAllocator = ValgrindAllocator;
+
+unsafe impl Sync for ValgrindAllocator {}
+
+unsafe impl GlobalAlloc for ValgrindAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let cc: &[u8] = b"cc"; // TODO: Set a unique identifier here?
+        vgPlain_malloc(cc.as_ptr() as *const c_char, layout.size()) as *mut u8
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        vgPlain_free(ptr as *mut c_void);
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn hello_world(
@@ -23,7 +65,9 @@ pub extern "C" fn hello_world(
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     let msg = CStr::from_bytes_with_nul(b"Panicked!\n\0").unwrap();
-    unsafe { libc_stuff::printf(msg.as_ptr()); }
+    unsafe {
+        libc_stuff::printf(msg.as_ptr());
+    }
     core::intrinsics::abort()
 }
 

--- a/krabcake/rs_hello/src/libc_stuff.rs
+++ b/krabcake/rs_hello/src/libc_stuff.rs
@@ -8,27 +8,44 @@
 //! The easiest thing to do was to just call out to all the local definitions
 //! for these methods that Valgrind itself provides.
 
-use core::ffi::{c_char,c_int,CStr,c_size_t,c_void};
+use core::ffi::{c_char, c_int, c_size_t, c_void, CStr};
 
 #[no_mangle]
 pub unsafe extern "C" fn printf(s: *const c_char) -> usize {
-    extern "C" { fn vgPlain_printf(s: *const c_char, ...) -> usize; }
+    extern "C" {
+        fn vgPlain_printf(s: *const c_char, ...) -> usize;
+    }
     unsafe { vgPlain_printf(s) }
 }
 
 #[no_mangle]
 unsafe extern "C" fn strlen(s: *const c_char) -> usize {
-    extern "C" { fn vgPlain_strlen(s: *const c_char) -> usize; }
+    extern "C" {
+        fn vgPlain_strlen(s: *const c_char) -> usize;
+    }
     unsafe { vgPlain_strlen(s) }
 }
 
 #[no_mangle]
 unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
-    extern "C" { fn vgPlain_memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize; }
+    extern "C" {
+        fn vgPlain_memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize;
+    }
     unsafe { vgPlain_memcmp(s1, s2, n) }
 }
 
 #[no_mangle]
 unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
     unsafe { memcmp(s1, s2, n) }
+}
+
+// Only empty definition is needed; we just need it to compile
+#[repr(C)]
+pub struct _Unwind_Exception {}
+
+// From https://github.com/rust-lang/rust/blob/480068c2359ea65df4481788b5ce717a548ce171/library/unwind/src/libunwind.rs#L105-L107
+#[no_mangle]
+unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> ! {
+    // Looping because of ! type
+    loop {}
 }


### PR DESCRIPTION
This patch creates a global allocator that uses the implementation provided by Valgrind (which lives in coregrind).

This allows us to pull in the `alloc` crate.