### PR TITLE
Build for 64-bit and 32-bit in distinct directories.

### DIFF
--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -5,6 +5,8 @@ EXTRA_DIST = docs/kc-manual.xml
 RSHELLO_DIR = rs_hello
 # RSHELLO_TARGET = $(RSHELLO_DIR)/target/release
 RSHELLO_TARGET = $(RSHELLO_DIR)/target/debug
+RSHELLO_TARGET_DEBUG64 = $(RSHELLO_DIR)/target/debug64
+RSHELLO_TARGET_DEBUG32 = $(RSHELLO_DIR)/target/debug32
 
 #$(RSHELLO_TARGET)/librs_hello.a:
 #	cd $(srcdir)/$(RSHELLO_DIR); \
@@ -14,13 +16,21 @@ RSHELLO_TARGET = $(RSHELLO_DIR)/target/debug
 # $(RSHELLO_TARGET)/librs_hello.a:
 #	cd $(srcdir)/$(RSHELLO_DIR) && $(CARGO) build --release
 
-$(RSHELLO_TARGET)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
+$(RSHELLO_TARGET)/librs_hello.amd64.a: $(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a
 	mkdir -p $(RSHELLO_TARGET)
+	cp $< $@
+
+$(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a
+	mkdir -p $(RSHELLO_TARGET)
+	cp $< $@
+
+$(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
+	mkdir -p $(RSHELLO_TARGET_DEBUG64)
 	rustup target add x86_64-unknown-linux-gnu
 	rustc -g --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
-$(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
-	mkdir -p $(RSHELLO_TARGET)
+$(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
+	mkdir -p $(RSHELLO_TARGET_DEBUG32)
 	rustup target add i586-unknown-linux-gnu
 	rustc -g --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 


### PR DESCRIPTION
I saw evidence that `make -j128` was failing in hard to diagnose ways because these two builds were interfering.

To prevent that, do the 64-bit and 32-bit builds in distinct directories.  (I bet cargo would do this for us, I should look into trying to use cargo directly instead of continuing with manual rustc invocations.)