### PR TITLE
krabcake: Add cmdline flag "--normalize-output" for UI testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code    
+        uses: actions/checkout@v3
+      - name: Build rs_hello
+        run: cd krabcake/rs_hello && cargo build --release
+      - name: Test rs_hello
+        run: cd krabcake/rs_hello && cargo test

--- a/krabcake/kc_main.c
+++ b/krabcake/kc_main.c
@@ -29,6 +29,7 @@
 #include "pub_tool_basics.h"
 #include "pub_tool_libcprint.h"
 #include "pub_tool_libcassert.h"
+#include "pub_tool_options.h"
 #include "pub_tool_tooliface.h"
 
 #include "krabcake.h" /* for client requests */
@@ -1012,8 +1013,22 @@ static void kc_fini(Int exitcode)
 {
 }
 
+struct RsClientContext {
+   Bool normalizeOutput;
+};
+
 static Bool kc_process_cmd_line_options(const HChar* arg)
 {
+   Bool   tmp_show;
+
+   // FIXME(bryangarza): Document this command-line flag?
+   if VG_BOOL_CLO(arg, "--normalize-output", tmp_show) {
+      if (tmp_show) {
+         struct RsClientContext rs_client_ctx;
+         rs_client_ctx.normalizeOutput = True;
+         rs_client_set_context(rs_client_ctx);
+      }
+   }
    return True;
 }
 
@@ -1031,6 +1046,7 @@ static void kc_print_debug_usage(void)
    );
 }
 
+extern void rs_client_set_context ( struct RsClientContext ctx );
 extern Bool rs_client_request_borrow_mut ( ThreadId tid, UWord* arg, UWord* ret );
 extern Bool rs_client_request_borrow_shr ( ThreadId tid, UWord* arg, UWord* ret );
 extern Bool rs_client_request_as_raw ( ThreadId tid, UWord* arg, UWord* ret );

--- a/krabcake/rs_hello/src/data.rs
+++ b/krabcake/rs_hello/src/data.rs
@@ -1,0 +1,195 @@
+use alloc::vec::Vec;
+
+use crate::{vg_addr, COUNTER, CTX, STACKS};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Tag(pub u64);
+
+impl Tag {
+    pub fn next(self) -> Tag {
+        Tag(self.0 + 1)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Item {
+    Unique(Tag),
+}
+
+impl Item {
+    pub fn num(&self) -> u64 {
+        match *self {
+            Item::Unique(Tag(val)) => val,
+        }
+    }
+}
+
+pub struct Stack {
+    pub addr: vg_addr,
+    // A unique ID, used in lieu of the address when printing
+    // Should only be used when opted into with `--normalize-output`
+    pub id: u64,
+    pub items: Vec<Item>,
+}
+
+impl Stack {
+    pub fn dbg_id(&self) -> u64 {
+        unsafe {
+            if CTX.normalize_output {
+                self.id
+            } else {
+                self.addr as u64
+            }
+        }
+    }
+}
+
+pub struct Stacks(pub Vec<Stack>);
+
+impl Stacks {
+    // Add a new stack and return its index
+    fn add_new_stack(&mut self, addr: vg_addr, items: Vec<Item>) -> usize {
+        let id = self.next_id();
+        let stack = Stack { addr, id, items };
+        self.0.push(stack);
+        self.0.len() - 1
+    }
+
+    /// Pushes an address into a new or existing stack, returning the index of that stack
+    pub fn push(&mut self, addr: vg_addr) -> usize {
+        unsafe {
+            for (idx, stack) in &mut self.0.iter_mut().enumerate() {
+                if stack.addr == addr {
+                    stack.items.push(Item::Unique(COUNTER));
+                    return idx;
+                }
+            }
+
+            let mut items = Vec::new();
+            items.push(Item::Unique(COUNTER));
+            self.add_new_stack(addr, items)
+        }
+    }
+
+    // Get the next ID (currently, it is just monotonically increasing)
+    fn next_id(&self) -> u64 {
+        self.0.last().map(|stack| stack.id + 1).unwrap_or_default()
+    }
+
+    // To reserve each dbg id, add an empty `Vec` into Stacks
+    // FIXME: Optimize this in the future
+    fn reserve_dbg_id(&mut self, addr: vg_addr) -> u64 {
+        let id = self.next_id();
+        let stack = Stack {
+            addr,
+            id,
+            items: Vec::new(),
+        };
+        self.0.push(stack);
+        id
+    }
+
+    pub fn if_addr_has_stack_then<T>(
+        &mut self,
+        addr: vg_addr,
+        process_stack: impl FnOnce(&mut Stack) -> T,
+    ) -> Option<T> {
+        for mut stack in &mut self.0 {
+            if stack.addr == addr {
+                return Some(process_stack(&mut stack));
+            }
+        }
+        None
+    }
+
+    pub fn get_stack_dbg_id_or_assign(&mut self, addr: vg_addr) -> u64 {
+        unsafe {
+            if CTX.normalize_output {
+                self.if_addr_has_stack_then(addr, |stack| stack.dbg_id())
+                    .unwrap_or_else(|| self.reserve_dbg_id(addr))
+            } else {
+                addr as u64
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use crate::Context;
+
+    use super::*;
+
+    const STARTING_DBG_ID: u64 = 8080;
+
+    // Utility to create a `Stacks` with one item, with an arbitrary ID.
+    // Just using this so that the IDs don't align with the indices, otherwise
+    // the assertions become confusing to read.
+    fn new_stacks(addr: vg_addr) -> Stacks {
+        unsafe {
+            let mut items = Vec::new();
+            items.push(Item::Unique(COUNTER));
+            let stack = Stack {
+                addr,
+                id: STARTING_DBG_ID,
+                items,
+            };
+            Stacks(vec![stack])
+        }
+    }
+
+    #[test]
+    fn push_to_stack() {
+        let mut stacks = new_stacks(0xdeadbeef);
+        assert_eq!(1, stacks.push(101));
+        assert_eq!(2, stacks.push(102));
+        assert_eq!(3, stacks.push(103));
+    }
+
+    #[test]
+    fn get_dbg_ids() {
+        let mut stacks = new_stacks(0xdeadbeef);
+        stacks.push(101);
+        stacks.push(102);
+        stacks.push(103);
+        // We always just get the addr back
+        assert_eq!(101, stacks.get_stack_dbg_id_or_assign(101));
+        assert_eq!(102, stacks.get_stack_dbg_id_or_assign(102));
+        assert_eq!(103, stacks.get_stack_dbg_id_or_assign(103));
+        assert_eq!(104, stacks.get_stack_dbg_id_or_assign(104));
+        assert_eq!(105, stacks.get_stack_dbg_id_or_assign(105));
+        assert_eq!(4, stacks.0.len());
+    }
+
+    #[test]
+    fn get_dbg_ids_normalized() {
+        unsafe {
+            CTX = Context {
+                normalize_output: true,
+            };
+        }
+        let mut stacks = new_stacks(0xdeadbeef);
+        stacks.push(101);
+        stacks.push(102);
+        stacks.push(103);
+        // Here we actually use the `id` field in whatever is the last Stack
+        assert_eq!(STARTING_DBG_ID + 1, stacks.get_stack_dbg_id_or_assign(101));
+        assert_eq!(STARTING_DBG_ID + 2, stacks.get_stack_dbg_id_or_assign(102));
+        assert_eq!(STARTING_DBG_ID + 3, stacks.get_stack_dbg_id_or_assign(103));
+        assert_eq!(STARTING_DBG_ID + 4, stacks.get_stack_dbg_id_or_assign(104));
+        assert_eq!(STARTING_DBG_ID + 5, stacks.get_stack_dbg_id_or_assign(105));
+        // This is because currently, the above 2 lines each add a new empty `Vec` into Stacks
+        // (Because `normalize_output` is true)
+        assert_eq!(6, stacks.0.len());
+        // (Should be the 4th item
+        // Before this line, the `Vec` was already there, but until now, it was empty
+        assert_eq!(4, stacks.push(104));
+        // Same index because we just add to existing Stack
+        assert_eq!(4, stacks.push(104));
+        // Adds at the end
+        assert_eq!(6, stacks.push(106));
+        assert_eq!(STARTING_DBG_ID + 6, stacks.get_stack_dbg_id_or_assign(106));
+    }
+}

--- a/krabcake/rs_hello/src/lib.rs
+++ b/krabcake/rs_hello/src/lib.rs
@@ -13,9 +13,12 @@ use core::alloc::{GlobalAlloc, Layout};
 
 // Can now import and use anything in alloc
 use alloc::vec::Vec;
+use data::{Item, Stack, Tag};
 
+use self::data::Stacks;
 use self::vex_ir::IROp;
 
+mod data;
 mod vex_ir;
 
 extern "C" {
@@ -36,6 +39,7 @@ extern "C" {
 
 struct ValgrindAllocator;
 
+#[cfg(not(test))]
 #[global_allocator]
 static ALLOCATOR: ValgrindAllocator = ValgrindAllocator;
 
@@ -94,6 +98,7 @@ pub extern "C" fn hello_world_old(
     printn(msg.as_ptr() as *const c_char, msg.len());
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     let msg = CStr::from_bytes_with_nul(b"Panicked!\n\0").unwrap();
@@ -103,6 +108,7 @@ fn panic(_info: &PanicInfo) -> ! {
     core::intrinsics::abort()
 }
 
+#[cfg(not(test))]
 #[lang = "eh_personality"]
 fn rust_eh_personality() {
     core::intrinsics::abort()
@@ -112,29 +118,19 @@ fn rust_eh_personality() {
 // "if you cannot beat 'em, join 'em."
 mod libc_stuff;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
-struct Tag(u64);
-
-impl Tag {
-    fn next(self) -> Tag {
-        Tag(self.0 + 1)
-    }
+#[derive(Default)]
+#[repr(C)]
+pub struct Context {
+    /// Use consistent IDs instead of pointer adresses that may change across runs.
+    /// Used only for tests.
+    normalize_output: bool,
 }
 
+static mut CTX: Context = Context {
+    normalize_output: false,
+};
 static mut COUNTER: Tag = Tag(0);
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-enum Item {
-    Unique(Tag),
-}
-
-impl Item {
-    fn num(&self) -> u64 {
-        match *self {
-            Item::Unique(Tag(val)) => val,
-        }
-    }
-}
+static mut STACKS: Stacks = Stacks(Vec::new());
 
 // FIXME: Need to more clearly distinguish between addresses and
 // shadowing of values. I.e. the tag here needs to be attached to the
@@ -144,8 +140,6 @@ static mut TRACKED_ADDRS: Vec<(vg_addr, Tag)> = Vec::new();
 static mut TRACKED_TEMPS: Vec<(vg_uint, Tag)> = Vec::new();
 // "GREG" is "Guest Register", i.e. the emulated registers.
 static mut TRACKED_GREGS: Vec<(vg_ulong, Tag)> = Vec::new();
-
-static mut STACKS: Vec<(vg_addr, Vec<Item>)> = Vec::new();
 
 // FIXME UGLY HACK
 // this is a big bad hack: I haven't managed to connect up
@@ -256,18 +250,12 @@ fn if_addr_tracked_then<T>(addr: vg_addr, process_tag: impl FnOnce(Tag) -> T) ->
     None
 }
 
-fn if_addr_has_stack_then<T>(
-    addr: vg_addr,
-    process_stack: impl FnOnce(&mut Vec<Item>) -> T,
-) -> Option<T> {
+#[no_mangle]
+pub extern "C" fn rs_client_set_context(ctx: Context) {
     unsafe {
-        for entry in &mut STACKS {
-            if entry.0 == addr {
-                return Some(process_stack(&mut entry.1));
-            }
-        }
+        vgPlain_dmsg("lib.rs: normalizing output...\n\0".as_ptr() as *const c_char);
+        CTX = ctx;
     }
-    None
 }
 
 #[no_mangle]
@@ -277,21 +265,15 @@ pub extern "C" fn rs_client_request_borrow_mut(
     ret: *mut c_size_t,
 ) -> bool {
     unsafe {
-        vgPlain_dmsg(
-            "lib.rs: handle client request BORROW_MUT 0x%llx\n\0".as_ptr() as *const c_char,
-            *arg.offset(1),
-            ret,
-        );
         COUNTER = COUNTER.next();
         let addr = *arg.offset(1) as vg_addr;
-        let lookup = if_addr_has_stack_then(addr, |entries| {
-            entries.push(Item::Unique(COUNTER));
-        });
-        if lookup.is_none() {
-            let mut v = Vec::new();
-            v.push(Item::Unique(COUNTER));
-            STACKS.push((addr, v));
-        }
+        let stack_idx = STACKS.push(addr);
+        let stack_dbg_id = STACKS.0.get(stack_idx).unwrap().dbg_id();
+        vgPlain_dmsg(
+            "lib.rs: handle client request BORROW_MUT 0x%llx\n\0".as_ptr() as *const c_char,
+            stack_dbg_id,
+            ret,
+        );
         assert!(STACKED_BORROW_EVENT.is_none());
         STACKED_BORROW_EVENT = Some((SbEventKind::BorrowMut, addr, COUNTER));
 
@@ -417,38 +399,39 @@ unsafe fn check_use_1(addr: vg_addr, shadow_addr: vg_ulong) {
     //
     // 3. as a side-effect of the access, we must pop all entries that
     //    lay above the aforementioned Unique(T).
-    let lookup = if_addr_has_stack_then(addr, |stack| {
-        let before_len = stack.len();
-        while let Some(last) = stack.last() {
+    //TODO(bryangarza): Have to bring this fn back from the dead???
+    let lookup = STACKS.if_addr_has_stack_then(addr, |stack| {
+        let before_len = stack.items.len();
+        while let Some(last) = stack.items.last() {
             msg!(
                 b"tag search seeking %d and saw %d\n\0",
                 shadow_addr,
                 last.num()
             );
             if last == &Item::Unique(Tag(shadow_addr)) {
-                let after_len = stack.len();
-                return (true, before_len, after_len);
+                let after_len = stack.items.len();
+                return (stack.dbg_id(), true, before_len, after_len);
             } else {
-                stack.pop();
+                stack.items.pop();
             }
         }
-        let after_len = stack.len();
-        (false, before_len, after_len)
+        let after_len = stack.items.len();
+        (stack.dbg_id(), false, before_len, after_len)
     });
     match lookup {
         None => {
             alert!(b"ALERT no stack for address 0x%08llx even though we are accessing it via pointer with tag %d\n\0",
-			   addr,
+			   STACKS.get_stack_dbg_id_or_assign(addr),
 			   shadow_addr);
         }
-        Some((false, _, _)) => {
+        Some((stack_dbg_id, false, _, _)) => {
             alert!(b"ALERT could not find tag in stack for address 0x%08llx even though we are accesing it via pointer with tag %d\n\0",
-			   addr,
+			   stack_dbg_id,
 			   shadow_addr);
         }
-        Some((true, before_len, after_len)) => {
+        Some((stack_dbg_id, true, before_len, after_len)) => {
             msg!(b"found tag in stack for address 0x%08llx when accessing via pointer with tag %d; stack len before: %d after: %d\n\0",
-			 addr,
+			 stack_dbg_id,
 			 shadow_addr,
 			 before_len,
 			 after_len);
@@ -521,7 +504,7 @@ pub extern "C" fn rs_trace_store(
             || {
                 msg!(
                     b" addr: 0x%08llx data: %d (0x%08llx) shadow_addr: %d shadow_data: %d \n\0",
-                    addr,
+                    STACKS.get_stack_dbg_id_or_assign(addr),
                     data,
                     data,
                     shadow_addr,
@@ -533,7 +516,7 @@ pub extern "C" fn rs_trace_store(
     if_addr_tracked_then(addr as vg_addr, |tag| unsafe {
         msg!(
             b"rs_trace_store tracked addr 0x%08llx shadow_addr: %d shadow_data: %d has tag %d\n\0",
-            addr,
+            STACKS.get_stack_dbg_id_or_assign(addr),
             shadow_addr,
             shadow_data,
             tag.0,
@@ -542,28 +525,30 @@ pub extern "C" fn rs_trace_store(
 
     if_addr_tracked_then(data as vg_addr, |tag| unsafe {
         msg!(
-            b"rs_trace_store tracked data %d (0x%08llx) shadow_addr: %d shadow_data: %d has tag %d\n\0",
+            b"rs_trace_store tracked data %d (addr: 0x%08llx) shadow_addr: %d shadow_data: %d has tag %d\n\0",
             data,
-            data,
+            STACKS.get_stack_dbg_id_or_assign(addr),
             shadow_addr,
             shadow_data,
             tag.0,
         );
     });
 
-    if_addr_has_stack_then(addr, |stack| unsafe {
-        msg!(
-            b"rs_trace_store has stack on addr 0x%08llx has stack len: %d\n\0",
-            addr,
-            stack.len(),
-        );
-    });
+    unsafe {
+        STACKS.if_addr_has_stack_then(addr, |stack| unsafe {
+            msg!(
+                b"rs_trace_store has stack on addr 0x%08llx has stack len: %d\n\0",
+                STACKS.get_stack_dbg_id_or_assign(addr),
+                stack.items.len(),
+            );
+        })
+    };
 
     unsafe {
         if shadow_addr != 0 || shadow_data != 0 {
             msg!(
                 b"rs_trace_store non-trivial shadow on addr: 0x%llx data: %d (0x%08llx) shadow_addr: %d shadow_data: %d \n\0",
-                addr,
+                STACKS.get_stack_dbg_id_or_assign(addr),
                 data,
                 data,
                 shadow_addr,
@@ -620,7 +605,12 @@ pub extern "C" fn rs_trace_store256(
     unsafe {
         if_sb_event_queued_print(
             || msg!(b"rs_trace_store256 sb event \0"),
-            || msg!(b" addr: 0x%08llx \n\0", addr),
+            || {
+                msg!(
+                    b" addr: 0x%08llx \n\0",
+                    STACKS.get_stack_dbg_id_or_assign(addr)
+                )
+            },
         );
     }
 }
@@ -630,7 +620,12 @@ pub extern "C" fn rs_trace_llsc(addr: vg_addr) {
     unsafe {
         if_sb_event_queued_print(
             || msg!(b"rs_trace_store sb event \0"),
-            || msg!(b" addr: 0x%08llx \n\0", addr),
+            || {
+                msg!(
+                    b" addr: 0x%08llx \n\0",
+                    STACKS.get_stack_dbg_id_or_assign(addr)
+                )
+            },
         );
     }
 }
@@ -642,10 +637,10 @@ pub extern "C" fn rs_trace_put(put_offset: vg_ulong, data: vg_ulong, shadow_data
             || msg!(b"rs_trace_put sb event \0"),
             || {
                 msg!(
-                    b" put_offset: %u data: %d (0x%08llx) shadow_data: %d\n\0",
+                    b" put_offset: %u data: %d (addr: 0x%08llx) shadow_data: %d\n\0",
                     put_offset,
                     data,
-                    data,
+                    STACKS.get_stack_dbg_id_or_assign(data),
                     shadow_data,
                 )
             },
@@ -654,10 +649,10 @@ pub extern "C" fn rs_trace_put(put_offset: vg_ulong, data: vg_ulong, shadow_data
     unsafe {
         if shadow_data != 0 {
             msg!(
-                b"rs_trace_put non-trivial shadow on data at offset: %lld data: %d (0x%08llx) shadow_data: %d \n\0",
+                b"rs_trace_put non-trivial shadow on data at offset: %lld data: %d (addr: 0x%08llx) shadow_data: %d \n\0",
                 put_offset,
                 data,
-                data,
+                STACKS.get_stack_dbg_id_or_assign(data),
                 shadow_data,
             );
             TRACKED_GREGS.push((put_offset, Tag(shadow_data as u64)));
@@ -668,23 +663,25 @@ pub extern "C" fn rs_trace_put(put_offset: vg_ulong, data: vg_ulong, shadow_data
 
     if_addr_tracked_then(data as vg_addr, |tag| unsafe {
         msg!(
-            b"rs_trace_put tracked data offset %lld data %d (0x%08llx) shadow_data: %d has tag %d\n\0",
+            b"rs_trace_put tracked data offset %lld data %d (addr: 0x%08llx) shadow_data: %d has tag %d\n\0",
             put_offset,
             data,
-            data,
+            STACKS.get_stack_dbg_id_or_assign(data),
             shadow_data,
             tag.0,
         );
     });
 
-    if_addr_has_stack_then(data as vg_addr, |entries| unsafe {
-        msg!(
-            b"rs_trace_put has stack on data offset %lld data %d (0x%08llx)\n\0",
-            put_offset,
-            data,
-            data,
-        );
-    });
+    unsafe {
+        STACKS.if_addr_has_stack_then(data as vg_addr, |_stack| unsafe {
+            msg!(
+                b"rs_trace_put has stack on data offset %lld data %d (addr: 0x%08llx)\n\0",
+                put_offset,
+                data,
+                STACKS.get_stack_dbg_id_or_assign(data),
+            );
+        })
+    };
 }
 
 #[no_mangle]
@@ -738,17 +735,23 @@ pub extern "C" fn rs_trace_puti(
 
     if_addr_tracked_then(data as vg_addr, |tag| unsafe {
         msg!(
-            b"rs_trace_puti data %d (0x%08llx) shadow_data: %d has tag %d\n\0",
+            b"rs_trace_puti data %d (addr: 0x%08llx) shadow_data: %d has tag %d\n\0",
             data,
-            data,
+            STACKS.get_stack_dbg_id_or_assign(data),
             shadow_data,
             tag.0,
         );
     });
 
-    if_addr_has_stack_then(data as vg_addr, |entries| unsafe {
-        msg!(b"rs_trace_puti data %d (0x%08llx)\n\0", data, data,);
-    });
+    unsafe {
+        STACKS.if_addr_has_stack_then(data as vg_addr, |_stack| unsafe {
+            msg!(
+                b"rs_trace_puti data %d (addr: 0x%08llx)\n\0",
+                data,
+                STACKS.get_stack_dbg_id_or_assign(data)
+            );
+        });
+    };
 }
 
 #[no_mangle]
@@ -909,40 +912,45 @@ pub extern "C" fn rs_shadow_unop(op: vg_long, s1: vg_long) -> vg_long {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_shadow_load(addr: vg_long, s1: vg_long) -> vg_long {
+pub extern "C" fn rs_shadow_load(addr: vg_addr, s1: vg_long) -> vg_long {
     unsafe {
         if_sb_event_queued_print(
             || msg!(b"rs_shadow_load sb event \0"),
-            || msg!(b" addr: 0x%08llx \n\0", addr),
+            || {
+                msg!(
+                    b" addr: 0x%08llx \n\0",
+                    STACKS.get_stack_dbg_id_or_assign(addr)
+                )
+            },
         );
     }
     unsafe {
         if s1 != 0 {
             msg!(
                 b"rs_shadow_load non-trivial shadow for addr 0x%08llx s1: %d\n\0",
-                addr,
+                STACKS.get_stack_dbg_id_or_assign(addr),
                 s1,
             );
         }
-        if_addr_tracked_then(addr as vg_addr, |tag| unsafe {
+        if_addr_tracked_then(addr, |tag| {
             msg!(
                 b"rs_shadow_load tracked addr 0x%08llx s1: %d has tag %d\n\0",
-                addr,
+                STACKS.get_stack_dbg_id_or_assign(addr),
                 s1,
                 tag.0,
             );
         });
-        if_addr_has_stack_then(addr as vg_addr, |stack| unsafe {
+        STACKS.if_addr_has_stack_then(addr, |stack| {
             msg!(
                 b"rs_shadow_load addr 0x%08llx s1: %d has stack len: %d\n\0",
-                addr,
+                stack.dbg_id(),
                 s1,
-                stack.len(),
+                stack.items.len(),
             );
         });
 
         if s1 != 0 {
-            check_use_1(addr as vg_addr, s1 as u64);
+            check_use_1(addr, s1 as u64);
         }
     }
 
@@ -1016,7 +1024,7 @@ pub extern "C" fn rs_shadow_get(offset: vg_long, ty: vg_long) -> vg_long {
             let addr = event.1;
             ret = (event.2).0 as vg_long;
 
-            msg!(b"hack attaching %d to reg offset: %d with expectation that it has value 0x%08llx\n\0", ret, offset, addr);
+            msg!(b"hack attaching %d to reg offset: %d with expectation that it has value 0x%08llx\n\0", ret, offset, STACKS.get_stack_dbg_id_or_assign(addr));
             STACKED_BORROW_EVENT = None;
         }
     }

--- a/krabcake/rs_hello/src/libc_stuff.rs
+++ b/krabcake/rs_hello/src/libc_stuff.rs
@@ -10,11 +10,13 @@
 
 use core::ffi::{c_char, c_int, c_size_t, c_void, CStr};
 
+#[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn printf(s: *const c_char) -> usize {
     unsafe { super::vgPlain_printf(s) as usize }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn strlen(s: *const c_char) -> usize {
     extern "C" {
@@ -23,6 +25,7 @@ unsafe extern "C" fn strlen(s: *const c_char) -> usize {
     unsafe { vgPlain_strlen(s) }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
     extern "C" {
@@ -31,15 +34,18 @@ unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -
     unsafe { vgPlain_memcmp(s1, s2, n) }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
     unsafe { memcmp(s1, s2, n) }
 }
 
+#[cfg(not(test))]
 // Only empty definition is needed; we just need it to compile
 #[repr(C)]
 pub struct _Unwind_Exception {}
 
+#[cfg(not(test))]
 // From https://github.com/rust-lang/rust/blob/480068c2359ea65df4481788b5ce717a548ce171/library/unwind/src/libunwind.rs#L105-L107
 #[no_mangle]
 unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> ! {

--- a/krabcake/rs_hello/src/vex_ir.rs
+++ b/krabcake/rs_hello/src/vex_ir.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, dead_code)]
 
 #[repr(i64)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
- Add `Stack` and `Stacks` data types, and use these to encapsulate logic that is used for normalising the output produced by the tool.
- For now, only pointer addresses are normalized.