### PR TITLE
krabcake: Add cmdline flag "--normalize-output" for UI testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI Tests
+
+on:
+  push:
+    branches: [ krabcake-vg ]
+  pull_request:
+    branches: [ krabcake-vg ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build rs_hello
+        run: cd krabcake/rs_hello && cargo build --release
+      - name: Test rs_hello
+        run: cd krabcake/rs_hello && cargo test

--- a/krabcake/kc_main.c
+++ b/krabcake/kc_main.c
@@ -29,6 +29,7 @@
 #include "pub_tool_basics.h"
 #include "pub_tool_libcprint.h"
 #include "pub_tool_libcassert.h"
+#include "pub_tool_options.h"
 #include "pub_tool_tooliface.h"
 
 #include "krabcake.h" /* for client requests */
@@ -1012,8 +1013,22 @@ static void kc_fini(Int exitcode)
 {
 }
 
+struct RsClientContext {
+   Bool normalizeOutput;
+};
+
 static Bool kc_process_cmd_line_options(const HChar* arg)
 {
+   Bool   tmp_show;
+
+   // FIXME(bryangarza): Document this command-line flag?
+   if VG_BOOL_CLO(arg, "--normalize-output", tmp_show) {
+      if (tmp_show) {
+         struct RsClientContext rs_client_ctx;
+         rs_client_ctx.normalizeOutput = True;
+         rs_client_set_context(rs_client_ctx);
+      }
+   }
    return True;
 }
 
@@ -1031,6 +1046,7 @@ static void kc_print_debug_usage(void)
    );
 }
 
+extern void rs_client_set_context ( struct RsClientContext ctx );
 extern Bool rs_client_request_borrow_mut ( ThreadId tid, UWord* arg, UWord* ret );
 extern Bool rs_client_request_borrow_shr ( ThreadId tid, UWord* arg, UWord* ret );
 extern Bool rs_client_request_as_raw ( ThreadId tid, UWord* arg, UWord* ret );

--- a/krabcake/rs_hello/src/data.rs
+++ b/krabcake/rs_hello/src/data.rs
@@ -1,0 +1,195 @@
+use alloc::vec::Vec;
+
+use crate::{vg_addr, COUNTER, CTX, STACKS};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Tag(pub u64);
+
+impl Tag {
+    pub fn next(self) -> Tag {
+        Tag(self.0 + 1)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Item {
+    Unique(Tag),
+}
+
+impl Item {
+    pub fn num(&self) -> u64 {
+        match *self {
+            Item::Unique(Tag(val)) => val,
+        }
+    }
+}
+
+pub struct Stack {
+    pub addr: vg_addr,
+    // A unique ID, used in lieu of the address when printing
+    // Should only be used when opted into with `--normalize-output`
+    pub id: u64,
+    pub items: Vec<Item>,
+}
+
+impl Stack {
+    pub fn dbg_id(&self) -> u64 {
+        unsafe {
+            if CTX.normalize_output {
+                self.id
+            } else {
+                self.addr as u64
+            }
+        }
+    }
+}
+
+pub struct Stacks(pub Vec<Stack>);
+
+impl Stacks {
+    // Add a new stack and return its index
+    fn add_new_stack(&mut self, addr: vg_addr, items: Vec<Item>) -> usize {
+        let id = self.next_id();
+        let stack = Stack { addr, id, items };
+        self.0.push(stack);
+        self.0.len() - 1
+    }
+
+    /// Pushes an address into a new or existing stack, returning the index of that stack
+    pub fn push(&mut self, addr: vg_addr) -> usize {
+        unsafe {
+            for (idx, stack) in &mut self.0.iter_mut().enumerate() {
+                if stack.addr == addr {
+                    stack.items.push(Item::Unique(COUNTER));
+                    return idx;
+                }
+            }
+
+            let mut items = Vec::new();
+            items.push(Item::Unique(COUNTER));
+            self.add_new_stack(addr, items)
+        }
+    }
+
+    // Get the next ID (currently, it is just monotonically increasing)
+    fn next_id(&self) -> u64 {
+        self.0.last().map(|stack| stack.id + 1).unwrap_or_default()
+    }
+
+    // To reserve each dbg id, add an empty `Vec` into Stacks
+    // FIXME: Optimize this in the future
+    fn reserve_dbg_id(&mut self, addr: vg_addr) -> u64 {
+        let id = self.next_id();
+        let stack = Stack {
+            addr,
+            id,
+            items: Vec::new(),
+        };
+        self.0.push(stack);
+        id
+    }
+
+    pub fn if_addr_has_stack_then<T>(
+        &mut self,
+        addr: vg_addr,
+        process_stack: impl FnOnce(&mut Stack) -> T,
+    ) -> Option<T> {
+        for mut stack in &mut self.0 {
+            if stack.addr == addr {
+                return Some(process_stack(&mut stack));
+            }
+        }
+        None
+    }
+
+    pub fn get_stack_dbg_id_or_assign(&mut self, addr: vg_addr) -> u64 {
+        unsafe {
+            if CTX.normalize_output {
+                self.if_addr_has_stack_then(addr, |stack| stack.dbg_id())
+                    .unwrap_or_else(|| self.reserve_dbg_id(addr))
+            } else {
+                addr as u64
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use crate::Context;
+
+    use super::*;
+
+    const STARTING_DBG_ID: u64 = 8080;
+
+    // Utility to create a `Stacks` with one item, with an arbitrary ID.
+    // Just using this so that the IDs don't align with the indices, otherwise
+    // the assertions become confusing to read.
+    fn new_stacks(addr: vg_addr) -> Stacks {
+        unsafe {
+            let mut items = Vec::new();
+            items.push(Item::Unique(COUNTER));
+            let stack = Stack {
+                addr,
+                id: STARTING_DBG_ID,
+                items,
+            };
+            Stacks(vec![stack])
+        }
+    }
+
+    #[test]
+    fn push_to_stack() {
+        let mut stacks = new_stacks(0xdeadbeef);
+        assert_eq!(1, stacks.push(101));
+        assert_eq!(2, stacks.push(102));
+        assert_eq!(3, stacks.push(103));
+    }
+
+    #[test]
+    fn get_dbg_ids() {
+        let mut stacks = new_stacks(0xdeadbeef);
+        stacks.push(101);
+        stacks.push(102);
+        stacks.push(103);
+        // We always just get the addr back
+        assert_eq!(101, stacks.get_stack_dbg_id_or_assign(101));
+        assert_eq!(102, stacks.get_stack_dbg_id_or_assign(102));
+        assert_eq!(103, stacks.get_stack_dbg_id_or_assign(103));
+        assert_eq!(104, stacks.get_stack_dbg_id_or_assign(104));
+        assert_eq!(105, stacks.get_stack_dbg_id_or_assign(105));
+        assert_eq!(4, stacks.0.len());
+    }
+
+    #[test]
+    fn get_dbg_ids_normalized() {
+        unsafe {
+            CTX = Context {
+                normalize_output: true,
+            };
+        }
+        let mut stacks = new_stacks(0xdeadbeef);
+        stacks.push(101);
+        stacks.push(102);
+        stacks.push(103);
+        // Here we actually use the `id` field in whatever is the last Stack
+        assert_eq!(STARTING_DBG_ID + 1, stacks.get_stack_dbg_id_or_assign(101));
+        assert_eq!(STARTING_DBG_ID + 2, stacks.get_stack_dbg_id_or_assign(102));
+        assert_eq!(STARTING_DBG_ID + 3, stacks.get_stack_dbg_id_or_assign(103));
+        assert_eq!(STARTING_DBG_ID + 4, stacks.get_stack_dbg_id_or_assign(104));
+        assert_eq!(STARTING_DBG_ID + 5, stacks.get_stack_dbg_id_or_assign(105));
+        // This is because currently, the above 2 lines each add a new empty `Vec` into Stacks
+        // (Because `normalize_output` is true)
+        assert_eq!(6, stacks.0.len());
+        // (Should be the 4th item
+        // Before this line, the `Vec` was already there, but until now, it was empty
+        assert_eq!(4, stacks.push(104));
+        // Same index because we just add to existing Stack
+        assert_eq!(4, stacks.push(104));
+        // Adds at the end
+        assert_eq!(6, stacks.push(106));
+        assert_eq!(STARTING_DBG_ID + 6, stacks.get_stack_dbg_id_or_assign(106));
+    }
+}

--- a/krabcake/rs_hello/src/libc_stuff.rs
+++ b/krabcake/rs_hello/src/libc_stuff.rs
@@ -10,11 +10,13 @@
 
 use core::ffi::{c_char, c_int, c_size_t, c_void, CStr};
 
+#[cfg(not(test))]
 #[no_mangle]
 pub unsafe extern "C" fn printf(s: *const c_char) -> usize {
     unsafe { super::vgPlain_printf(s) as usize }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn strlen(s: *const c_char) -> usize {
     extern "C" {
@@ -23,6 +25,7 @@ unsafe extern "C" fn strlen(s: *const c_char) -> usize {
     unsafe { vgPlain_strlen(s) }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
     extern "C" {
@@ -31,15 +34,18 @@ unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -
     unsafe { vgPlain_memcmp(s1, s2, n) }
 }
 
+#[cfg(not(test))]
 #[no_mangle]
 unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: c_size_t) -> usize {
     unsafe { memcmp(s1, s2, n) }
 }
 
+#[cfg(not(test))]
 // Only empty definition is needed; we just need it to compile
 #[repr(C)]
 pub struct _Unwind_Exception {}
 
+#[cfg(not(test))]
 // From https://github.com/rust-lang/rust/blob/480068c2359ea65df4481788b5ce717a548ce171/library/unwind/src/libunwind.rs#L105-L107
 #[no_mangle]
 unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> ! {

--- a/krabcake/rs_hello/src/vex_ir.rs
+++ b/krabcake/rs_hello/src/vex_ir.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, dead_code)]
 
 #[repr(i64)]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
- Add `Stack` and `Stacks` data types, and use these to encapsulate logic that is used for normalising the output produced by the tool.
- For now, only pointer addresses are normalized.