### PR TITLE
Make shell stuff in Makefile a little more robust.

### DIFF
--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -26,13 +26,13 @@ $(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a
 
 $(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
 	mkdir -p $(RSHELLO_TARGET_DEBUG64)
-	[[ -n "$CI" ]] && ! rustup toolchain list | grep -q nightly && rustup toolchain install nightly
+	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
 	rustup target add x86_64-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
 $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
 	mkdir -p $(RSHELLO_TARGET_DEBUG32)
-	[[ -n "$CI" ]] && ! rustup toolchain list | grep -q nightly && rustup toolchain install nightly
+	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
 	rustup target add i586-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 


### PR DESCRIPTION
Make shell stuff in Makefile a little more robust.

 (Worth noting however that /bin/dash does not support the `[[ ... ]]` form so we'll have to deal with that at some point.)