### PR TITLE
further fixes to the Makefile.am

### DIFF
--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -17,26 +17,27 @@ RSHELLO_TARGET_DEBUG32 = $(RSHELLO_DIR)/target/debug32
 #	cd $(srcdir)/$(RSHELLO_DIR) && $(CARGO) build --release
 
 $(RSHELLO_TARGET)/librs_hello.amd64.a: $(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a
-	mkdir -p $(RSHELLO_TARGET)
+	mkdir -p $(dir $@)
 	cp $< $@
 
 $(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a
-	mkdir -p $(RSHELLO_TARGET)
+	mkdir -p $(dir $@)
 	cp $< $@
 
 
 $(RSHELLO_TARGET)/nightly_installed:
 #	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
+	mkdir -p $(dir $@)
 	if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
 	touch $@
 
 $(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
-	mkdir -p $(RSHELLO_TARGET_DEBUG64)
+	mkdir -p $(dir $@)
 	rustup target add x86_64-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
 $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
-	mkdir -p $(RSHELLO_TARGET_DEBUG32)
+	mkdir -p $(dir $@)
 	rustup target add i586-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 

--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -24,15 +24,19 @@ $(RSHELLO_TARGET)/librs_hello.x86.a: $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a
 	mkdir -p $(RSHELLO_TARGET)
 	cp $< $@
 
-$(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
+
+$(RSHELLO_TARGET)/nightly_installed:
+#	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
+	if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
+	touch $@
+
+$(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
 	mkdir -p $(RSHELLO_TARGET_DEBUG64)
-	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
 	rustup target add x86_64-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 
-$(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs
+$(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
 	mkdir -p $(RSHELLO_TARGET_DEBUG32)
-	[[ -n $$CI ]] && if ! rustup toolchain list | grep -q nightly ; then rustup toolchain install nightly; fi
 	rustup target add i586-unknown-linux-gnu
 	rustup run nightly rustc -g --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
 


### PR DESCRIPTION
further fixes to the Makefile.am

hopefully this one works better for all of us.

the main changes were:

1. unified the rule into one place. Before, if you did `make -jN`, it would quite easily attempt to call `rustup toolchain install nightly` *twice in parallel*, which was quite bad (not just in terms of performance; I don't think the `rustup` tool itself is designed to handle that scenario at all).
2. got rid of checking if we're running under CI. I think the check being done here applies reasonably well to either CI or nor CI context, and the CI checking as implemented was not shell-independent. (If we really want to do that inspection of an env var, we can do it in the makefile syntax itself, and e.g. make the rule recipe depend on the presence/absence of that variable)
