### PR TITLE
Start normalized addresses from something that does not look like nullptr

### DIFF
--- a/krabcake/rs_hello/src/data.rs
+++ b/krabcake/rs_hello/src/data.rs
@@ -73,7 +73,8 @@ impl Stacks {
 
     // Get the next ID (currently, it is just monotonically increasing)
     fn next_id(&self) -> u64 {
-        self.0.last().map(|stack| stack.id + 1).unwrap_or_default()
+        const INIT_NORM_ADDR: u64 = 0x10000000;
+        self.0.last().map(|stack| stack.id + 1).unwrap_or(INIT_NORM_ADDR)
     }
 
     // To reserve each dbg id, add an empty `Vec` into Stacks

--- a/krabcake/rs_hello/src/data.rs
+++ b/krabcake/rs_hello/src/data.rs
@@ -73,8 +73,8 @@ impl Stacks {
 
     // Get the next ID (currently, it is just monotonically increasing)
     fn next_id(&self) -> u64 {
-        const INIT_NORM_ADDR: u64 = 0x10000000;
-        self.0.last().map(|stack| stack.id + 1).unwrap_or(INIT_NORM_ADDR)
+        const INIT_NORM: u64 = 0x10000000;
+        self.0.last().map(|stack| stack.id + 1).unwrap_or(INIT_NORM)
     }
 
     // To reserve each dbg id, add an empty `Vec` into Stacks

--- a/krabcake/rs_hello/src/lib.rs
+++ b/krabcake/rs_hello/src/lib.rs
@@ -451,7 +451,7 @@ unsafe fn check_use_1(addr: vg_addr, shadow_addr: vg_ulong) {
                            shadow_addr);
         }
         Some((stack_dbg_id, false, _, _)) => {
-            alert!(b"ALERT could not find tag in stack for address 0x%08llx even though we are accesing it via pointer with tag %d\n\0",
+            alert!(b"ALERT could not find tag in stack for address 0x%08llx even though we are accessing it via pointer with tag %d\n\0",
                            stack_dbg_id,
                            shadow_addr);
         }


### PR DESCRIPTION
Start normalized addresses from something that does not look like nullptr

And while we're at it, fix a typo in the output.