### PR TITLE
Build the static lib atop cargo instead of atop Rust.

### DIFF
--- a/krabcake/Makefile.am
+++ b/krabcake/Makefile.am
@@ -34,12 +34,16 @@ $(RSHELLO_TARGET)/nightly_installed:
 $(RSHELLO_TARGET_DEBUG64)/librs_hello.amd64.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
 	mkdir -p $(dir $@)
 	rustup target add x86_64-unknown-linux-gnu
-	rustup run nightly rustc -g --edition=2021 --target=x86_64-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
+# When `-C` flag to cargo is stable, use it here instead of manually chdir'ing
+	cd $(RSHELLO_DIR) && cargo build --target=x86_64-unknown-linux-gnu
+	cp $(RSHELLO_DIR)/target/x86_64-unknown-linux-gnu/debug/librs_hello.a $@
 
 $(RSHELLO_TARGET_DEBUG32)/librs_hello.x86.a: $(RSHELLO_DIR)/src/lib.rs $(RSHELLO_DIR)/src/*.rs $(RSHELLO_TARGET)/nightly_installed
 	mkdir -p $(dir $@)
 	rustup target add i586-unknown-linux-gnu
-	rustup run nightly rustc -g --edition=2021 --target=i586-unknown-linux-gnu --crate-type=staticlib -C panic=abort $< -o $@
+# When `-C` flag to cargo is stable, use it here instead of manually chdir'ing
+	cd $(RSHELLO_DIR) && cargo build --target=i586-unknown-linux-gnu
+	cp $(RSHELLO_DIR)/target/i586-unknown-linux-gnu/debug/librs_hello.a $@
 
 clean-local:
 	cd $(srcdir)/$(RSHELLO_DIR); cargo clean


### PR DESCRIPTION
Build the static lib atop cargo instead of atop Rust.

Note: This is a pretty bad hack because it is still generating the file into a place that the makefile itself doesn't know about, and then copying it *from* there. This is not great form. We would be better off either:

1. Making the intermediate file its own target, and then having the copy as a separate rule, or
2. Revising the makefile to use cargo's notion of the target location instead of doing any copy at all.